### PR TITLE
Allow for zero in the sd for pattern

### DIFF
--- a/src/pydisagg/ihme/splitter/age_splitter.py
+++ b/src/pydisagg/ihme/splitter/age_splitter.py
@@ -176,7 +176,7 @@ class AgeSplitter(BaseModel):
         validate_index(pattern, self.pattern.index, name)
         validate_nonan(pattern, name)
         validate_positive(
-            pattern, [self.pattern.val_sd], name, strict=positive_strict
+            pattern, [self.pattern.val_sd], name, strict=False
         )
         validate_interval(
             pattern,

--- a/src/pydisagg/ihme/splitter/sex_splitter.py
+++ b/src/pydisagg/ihme/splitter/sex_splitter.py
@@ -120,7 +120,7 @@ class SexSplitter(BaseModel):
         pattern = pattern[self.pattern.columns].copy()
         validate_index(pattern, self.pattern.index, name)
         validate_nonan(pattern, name)
-        validate_positive(pattern, [self.pattern.val_sd], name)
+        validate_positive(pattern, [self.pattern.val_sd], name, strict = False)
         data_with_pattern = self._merge_with_pattern(data, pattern)
         return data_with_pattern
 


### PR DESCRIPTION
Removed strictness in pattern uncertainty validation. 
For age splitting, it was already not strict but I made it explicit in the code, only needed to change for sex splitting.